### PR TITLE
Rewrite routing logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": { "source.fixAll": true },
-  "deno.enable": true
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": { "source.fixAll": true },
+    "deno.enable": true,
+    "deno.config": "./deno.jsonc"
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,24 @@
+{
+    "fmt": {
+        "options": {
+            "indentWidth": 4,
+            "proseWrap": "preserve"
+        },
+        "files": {
+            "exclude": [
+                "./node_modules/",
+                "./out/",
+                "./package-lock.json"
+            ]
+        }
+    },
+    "lint": {
+        "files": {
+            "exclude": [
+                "./node_modules/",
+                "./out/",
+                "./package-lock.json"
+            ]
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
         "grammy": "^1.0.0"
     },
     "devDependencies": {
-        "deno2node": "0.4.0"
+        "deno2node": "^1.3.0"
     },
     "files": [
         "out/"
     ],
-    "main": "out/router.js",
+    "main": "out/mod.js",
     "type": "commonjs",
     "exports": {
-        ".": "./out/router.js"
+        ".": "./out/mod.js"
     },
     "keywords": [
         "router",

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,1 +1,1 @@
-export * from 'https://lib.deno.dev/x/grammy@v1/mod.ts'
+export * from "https://lib.deno.dev/x/grammy@v1/mod.ts";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,1 +1,1 @@
-export * from 'grammy'
+export * from "grammy";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,0 +1,1 @@
+export * from "./router.ts";

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,12 +1,12 @@
 import {
-    Middleware,
-    MiddlewareObj,
-    MiddlewareFn,
     Composer,
     Context,
-} from './deps.deno.ts'
+    Middleware,
+    MiddlewareFn,
+    MiddlewareObj,
+} from "./deps.deno.ts";
 
-type MaybePromise<T> = T | Promise<T>
+type MaybePromise<T> = T | Promise<T>;
 
 /**
  * A router lets you specify a number of middlewares, each of them identified by
@@ -36,7 +36,7 @@ type MaybePromise<T> = T | Promise<T>
  * ```
  */
 export class Router<C extends Context> implements MiddlewareObj<C> {
-    private otherwiseHandler: Composer<C> | undefined
+    private otherwiseHandler: Composer<C> | undefined;
 
     /**
      * Constructs a router with a routing function and optionally some
@@ -48,7 +48,7 @@ export class Router<C extends Context> implements MiddlewareObj<C> {
      */
     constructor(
         private readonly router: (ctx: C) => MaybePromise<string | undefined>,
-        public routeHandlers = new Map<string, Middleware<C>>()
+        public routeHandlers = new Map<string, Middleware<C>>(),
     ) {}
 
     /**
@@ -60,8 +60,8 @@ export class Router<C extends Context> implements MiddlewareObj<C> {
      * @param middleware The middleware to register
      */
     route(route: string, ...middleware: Array<Middleware<C>>) {
-        this.routeHandlers.set(route, new Composer(...middleware))
-        return this
+        this.routeHandlers.set(route, new Composer(...middleware));
+        return this;
     }
 
     /**
@@ -73,20 +73,20 @@ export class Router<C extends Context> implements MiddlewareObj<C> {
      * @param middleware Middleware to run if no route matches
      */
     otherwise(...middleware: Array<Middleware<C>>) {
-        this.otherwiseHandler = new Composer(...middleware)
-        return this
+        this.otherwiseHandler = new Composer(...middleware);
+        return this;
     }
 
     middleware(): MiddlewareFn<C> {
         return new Composer<C>()
-            .lazy(async ctx => {
-                const route = await this.router(ctx)
+            .lazy(async (ctx) => {
+                const route = await this.router(ctx);
                 return (
                     (route === undefined || !this.routeHandlers.has(route)
                         ? this.otherwiseHandler
                         : this.routeHandlers.get(route)) ?? []
-                )
+                );
             })
-            .middleware()
+            .middleware();
     }
 }


### PR DESCRIPTION
- Improves middleware tree integration, closes #1
- No longer duplicates routing logic with comopser
- Adds support maps objects (not just maps) for inital intitialization